### PR TITLE
Add converter to retrieve route

### DIFF
--- a/README
+++ b/README
@@ -1,0 +1,22 @@
+# WIP: Food registration API
+
+## About
+This application receives food business registrations, then forwards them to a mockup of Local Authority's MIS systems in the appropriate format.
+Additional capabilities are listed under 'features'.
+
+## Routes
+`/send` - Sends new registration details to a specified mock-MIS. See [exampleSend.json](exampleSend.json) for correct format of config and data.
+
+`/retrieve` - Retrieves all registration details from all mock-MIS stores.
+
+`/retrieve/:authorityCode` (e.g. `001`) - Retrieves all registration details from the specified mock-MIS store.
+
+## Options
+`?standardised=false` - When retrieving, you can use this query to return details in the native MIS format, rather than converting it back to the standardised format.
+
+## Features (WIP)
+- Convert from standardised format to custom LA format
+- Convert from custom LA format to standardised format
+- Send an email notification to a specified recipient
+- Validate the premises identified in a registration
+- Connect to FHRS

--- a/README
+++ b/README
@@ -15,8 +15,16 @@ Additional capabilities are listed under 'features'.
 `?standardised=false` - When retrieving, you can use this query to return details in the native MIS format, rather than converting it back to the standardised format.
 
 ## Features (WIP)
+- Randomised intentional failure for development
 - Convert from standardised format to custom LA format
 - Convert from custom LA format to standardised format
 - Send an email notification to a specified recipient
 - Validate the premises identified in a registration
 - Connect to FHRS
+
+## Pushing to GOV.UK PaaS
+1. Log in with `cf login -a api.cloud.service.gov.uk -u USERNAME`
+2. Enter the password
+3. Temporarily remove the node_modules directory (failing to do this will result in a symlink error)
+4. `cf push`
+5. Access at: `https://node-app-paas-test.cloudapps.digital` (the URL is determined by `manifest.yml`)

--- a/exampleSend.json
+++ b/exampleSend.json
@@ -1,0 +1,9 @@
+{
+    "config": {
+		    "authorityCode": "001"
+    },
+    "data": [
+        {"orgName": "My Old Dutch", "address": "131-132 High Holborn", "postcode": "WC1V 6PS"},
+        {"orgName": "Wahaca", "address": "20 Atlantic Rd Brixton", "postcode": "SW9 8JA"}
+    ]
+}

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,6 @@
+---
+applications:
+- name: node-app-paas-test
+  command: nodemon src/index.js
+  memory: 256M
+  buildpack: nodejs_buildpack

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "express": "4.16.2",
     "notifications-node-client": "4.1.0",
     "request": "2.83.0",
-    "winston": "2.4.0"
+    "winston": "2.4.0",
+    "nodemon": "1.13.3"
   },
   "devDependencies": {
     "eslint": "4.13.1",
@@ -38,7 +39,6 @@
     "eslint-plugin-import": "2.8.0",
     "eslint-plugin-jsx-a11y": "6.0.3",
     "eslint-plugin-react": "7.5.1",
-    "eslint-watch": "3.1.3",
-    "nodemon": "1.13.3"
+    "eslint-watch": "3.1.3"
   }
 }

--- a/src/api/retrieve/retrieve.controller.js
+++ b/src/api/retrieve/retrieve.controller.js
@@ -1,10 +1,28 @@
 const store = require('../../store');
 const winston = require('winston');
+const formatConverterService = require('../../services/format-converter.service');
 
-const retrieveAllLas = async () => {
+const convertRetrievedData = (data, authorityCode) => {
+  let convertedData = formatConverterService.convert(
+    data,
+    authorityCode,
+    'retrieve'
+  );
+
+  return convertedData;
+}
+
+const retrieveAllLas = async (standardisedSwitch) => {
   winston.info('retrieve.controller: retrieveAllLas called');
   try {
-    const result = await store.getAllLas();
+    let result = await store.getAllLas();
+    if(standardisedSwitch !== 'false') {
+      const resultConverted = {};
+      Object.keys(result).forEach((authorityCode) => {
+        resultConverted[authorityCode] = convertRetrievedData(result[authorityCode], authorityCode);
+      });
+      result = resultConverted;
+    }
     winston.info('retrieve.controller: retrieveAllLas succeeded');
     return result;
   } catch (err) {
@@ -13,9 +31,12 @@ const retrieveAllLas = async () => {
   }
 };
 
-const retrieveLa = async la => {
+const retrieveLa = async (la, standardisedSwitch) => {
   try {
-    const result = await store.getLa(la);
+    let result = await store.getLa(la);
+    if(standardisedSwitch !== 'false') {
+      result = convertRetrievedData(result, la);
+    }
     winston.info('retrieve.controller: retrieveLa succeeded');
     return result;
   } catch (err) {

--- a/src/api/retrieve/retrieve.router.js
+++ b/src/api/retrieve/retrieve.router.js
@@ -5,11 +5,11 @@ module.exports = () => {
   const router = Router();
 
   router.get('', async (req, res) => {
-    res.send(await retrieveController.retrieveAllLas());
+    res.send(await retrieveController.retrieveAllLas(req.query.standardised));
   });
 
   router.get('/:la', async (req, res) => {
-    res.send(await retrieveController.retrieveLa(req.params.la));
+    res.send(await retrieveController.retrieveLa(req.params.la, req.query.standardised));
   });
 
   return router;

--- a/src/api/send/send.controller.js
+++ b/src/api/send/send.controller.js
@@ -8,7 +8,8 @@ module.exports = async body => {
 
   const convertedData = formatConverterService.convert(
     body.data,
-    body.config.targetFormat
+    body.config.authorityCode,
+    'send'
   );
 
   try {
@@ -16,8 +17,9 @@ module.exports = async body => {
 
     const result = await store.pushToLa(
       validatedData,
-      body.config.destinationLA
+      body.config.authorityCode
     );
+
     notifyService.notify(process.env.EMAIL_TEMPLATE, body.email);
     return result;
   } catch (err) {

--- a/src/api/send/send.controller.js
+++ b/src/api/send/send.controller.js
@@ -20,7 +20,9 @@ module.exports = async body => {
       body.config.authorityCode
     );
 
-    notifyService.notify(process.env.EMAIL_TEMPLATE, body.email);
+    if(process.env.EMAIL_TEMPLATE && body.email) {
+      notifyService.notify(process.env.EMAIL_TEMPLATE, body.email);
+    }
     return result;
   } catch (err) {
     winston.error(`send controller error: ${err}`);

--- a/src/services/format-converter.service.js
+++ b/src/services/format-converter.service.js
@@ -1,25 +1,65 @@
-const targetFormats = {
+const formatMap = {
   northgate1: {
     orgName: 'organisationName',
     address: 'location',
   },
-  civica5: {},
-  idox2: {},
-  tascomi8: {},
+  civica5: {
+    orgName: 'company',
+    address: 'fullAddress',
+  },
+  idox2: {
+    orgName: 'businessName',
+    address: 'businessLocation',
+  },
+  tascomi8: {
+    orgName: 'companyName',
+    address: 'address',
+  },
 };
 
-const convert = (data, targetFormatName) => {
-  const targetFormat = targetFormats[targetFormatName];
+const authorityMap = {
+  '001': {
+    authorityName: 'bristol',
+    format: 'northgate1'
+  },
+  '002': {
+    authorityName: 'camden',
+    format: 'civica5'
+  },
+  '003': {
+    authorityName: 'winchester',
+    format: 'idox2'
+  }
+}
+
+const getFormatByAuthority = (authorityCode) => {
+  return authorityMap[authorityCode];
+}
+
+
+// 'direction' can be 'send' or 'retrieve'
+const convert = (data, authorityCode, direction) => {
+  const authorityFormat = getFormatByAuthority(authorityCode).format;
+  let format = formatMap[authorityFormat];
   const output = [];
 
+  if(direction === 'retrieve') {
+    let formatReversed = {};
+    for(var property in format) {
+      formatReversed[format[property] ] = property;
+    }
+    format = formatReversed;
+  }
+
+  // Convert each entry in the org
   data.forEach(org => {
-    const newOrg = {};
+    const newConvertedOrg = {};
 
     Object.keys(org).forEach(property => {
-      newOrg[targetFormat[property] || property] = org[property];
+      newConvertedOrg[format[property] || property] = org[property];
     });
 
-    output.push(newOrg);
+    output.push(newConvertedOrg);
   });
 
   return output;

--- a/src/services/notify.service.js
+++ b/src/services/notify.service.js
@@ -18,5 +18,4 @@ const notify = (template, email) => {
   });
 }
 
-  module.exports = { notify };
-  
+module.exports = { notify };

--- a/src/services/notify.service.js
+++ b/src/services/notify.service.js
@@ -1,21 +1,23 @@
 const { NotifyClient } = require('notifications-node-client');
 const winston = require('winston');
 
-const notifyClient = new NotifyClient(process.env.NOTIFY_KEY);
+if(process.env.NOTIFY_KEY) {
+  const notifyClient = new NotifyClient(process.env.NOTIFY_KEY);
 
-const notify = (template, email) => {
-  winston.info('notify.service: notify called');
-  return new Promise((resolve, reject) => {
-    notifyClient.sendEmail(template, email)
-      .then(response => {
-        winston.info('notify.service: notify successful')
-        resolve(response)
-      })
-      .catch(err => {
-        winston.info('notify.service: notify failed')
-        reject(err)
-      })
-  });
+  const notify = (template, email) => {
+    winston.info('notify.service: notify called');
+    return new Promise((resolve, reject) => {
+      notifyClient.sendEmail(template, email)
+        .then(response => {
+          winston.info('notify.service: notify successful')
+          resolve(response)
+        })
+        .catch(err => {
+          winston.info('notify.service: notify failed')
+          reject(err)
+        })
+    });
+  }
+
+  module.exports = { notify };
 }
-
-module.exports = { notify };

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -1,8 +1,8 @@
+// the councils' mock-mis stores/databases are identified here by their 'authority code' - 001 to 387 for instance.
 const store = {
-  camden: [],
-  bristol: [],
-  lambeth: [],
-  winchester: [],
+  '001': [], // e.g. bristol
+  '002': [], // e.g. camden
+  '003': [], // e.g. winchester
 };
 
 const randomlyFail = () => Math.random() > 0.9;


### PR DESCRIPTION
- Swapped authority names ('bristol') for codes ('001'), i.e. how it's done in FHRS.
- Added new conversion and options for `retrieve` route (below)
- Added new authority-to-format map, ultimately to be stored in its own database, to remove the need for specifying both the authority and the MIS format in requests.
- Added README and example JSON content for `/send` body
- Added Notify bypass in the event that API key or body.email aren't present
- Added `manifest.yml` for pushing to GOV.UK PaaS

`/retrieve` - gets registration records from all LAs, and converts data into the standardised format
`/retrieve/001` - gets registration records from LA with authority code 001, converts to standardised

`/retrieve?standardised=false` - this query skips the conversion step, displays the data exactly as it was stored.
`/retrieve/001?standardised=false` - same as above, for the specified LA only